### PR TITLE
Line length, typos and fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ This is a work in progress.
   
 ### Data Dictionary
 
-* [Star data](data_dictionary/star_data.md)
+* [Star data](data_dictionary/tables.md)
 
 ### Standards of Practice
 
 * [Versioning of code repositories](SOP/repo_versioning.md)
-* [Updating live star instance](SOP/updating_star.md)
+* [Updating live star instance](SOP/release_procedure.md)
 
 ### Technical Overview
 


### PR DESCRIPTION
Closes #44 

- Makes the line length consistent in Technical_overview_of_EMAP.md
- Fixes a couple of typos
- Fixes broken links from README